### PR TITLE
[step3,4] db ERD 작성 및 비관적 락을 통한 동시성 제어/통합 테스트

### DIFF
--- a/READ_ME.md
+++ b/READ_ME.md
@@ -1,0 +1,16 @@
+## ERD
+
+---
+
+![image](https://github.com/user-attachments/assets/6043fc94-f392-41b5-b856-ac7fdd54b9c4)
+
+![image](https://github.com/user-attachments/assets/9f3fbce5-c770-4e64-a8de-58b8049fe9b4)
+
+아래 2가지 요구 사항을 바탕으로 각각의 테이블을 만들었습니다.
+- 특강 조회 -> 특강(Lecture) 
+- 특강 신청 -> 특강신청(Lecture Application)
+
+특강(Lecture)은 제목과 시작 시간을 통해 최소한의 구분이 된다고 생각하였고 'step3의 제한인원'을 고려하여 최대 정원도 컬럼으로 넣게 되었습니다.
+
+특강 신청(Lecture Application)은 특강의 index와 신청자의 id를 통해서도 최소한의 기록이 된다고 판단했습니다.  
+'step4 중복 신청 제한'을 대비하여 중복된 레코드의 저장을 방지하고자 유니크 키도 설정하게 되었습니다.

--- a/src/main/java/hhplus/cleanarchitecture/application/LectureService.java
+++ b/src/main/java/hhplus/cleanarchitecture/application/LectureService.java
@@ -32,7 +32,7 @@ public class LectureService {
         final Long lectureId = lectureApplicationDto.lectureId();
         final String applicantId = lectureApplicationDto.applicantId();
 
-        Lecture lecture = lectureRepository.findById(lectureId)
+        Lecture lecture = lectureRepository.findByIdWithPessimisticLock(lectureId)
                 .orElseThrow(() -> new RestApiException(LectureErrorCode.LECTURE_NOT_FOUND));
 
         // 이미 종료된 특강인지 확인

--- a/src/main/java/hhplus/cleanarchitecture/infrastructure/LectureApplicationRepository.java
+++ b/src/main/java/hhplus/cleanarchitecture/infrastructure/LectureApplicationRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface LectureApplicationRepository extends JpaRepository<LectureApplication, Long> {
 
-    @Query("SELECT COUNT(la) FROM LectureApplication la WHERE la.id = :lectureId")
+    @Query("SELECT COUNT(la) FROM LectureApplication la WHERE la.lectureId = :lectureId")
     int countByLectureId(@Param("lectureId") Long lectureId);
 }

--- a/src/main/java/hhplus/cleanarchitecture/infrastructure/LectureRepository.java
+++ b/src/main/java/hhplus/cleanarchitecture/infrastructure/LectureRepository.java
@@ -1,8 +1,17 @@
 package hhplus.cleanarchitecture.infrastructure;
 
 import hhplus.cleanarchitecture.domain.Lecture;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface LectureRepository extends JpaRepository<Lecture, Long> {
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT l FROM Lecture l WHERE l.id = :id")
+    Optional<Lecture> findByIdWithPessimisticLock(@Param("id") Long id);
 }

--- a/src/test/java/hhplus/cleanarchitecture/lecture/LectureApplicationIntegrationTest.java
+++ b/src/test/java/hhplus/cleanarchitecture/lecture/LectureApplicationIntegrationTest.java
@@ -1,0 +1,104 @@
+package hhplus.cleanarchitecture.lecture;
+
+import hhplus.cleanarchitecture.application.LectureService;
+import hhplus.cleanarchitecture.application.dto.LectureApplicationDto;
+import hhplus.cleanarchitecture.application.exception.RestApiException;
+import hhplus.cleanarchitecture.domain.Lecture;
+import hhplus.cleanarchitecture.infrastructure.LectureApplicationRepository;
+import hhplus.cleanarchitecture.infrastructure.LectureRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LectureApplicationIntegrationTest {
+
+    @Autowired
+    private LectureService lectureService;
+
+    @Autowired
+    private LectureRepository lectureRepository;
+
+    @Autowired
+    private LectureApplicationRepository lectureApplicationRepository;
+
+    private Lecture testLecture;
+
+    @BeforeAll
+    void setUp() {
+        testLecture = lectureRepository.save(
+                Lecture.builder()
+                        .id(1L)
+                        .lectureTitle("자바/스프링 개발자를 위한 실용주의 프로그래밍")
+                        .lectureStartTime(LocalDateTime.now().plusHours(1))
+                        .lectureEndTime(LocalDateTime.now().plusHours(3))
+                        .lectureMaxParticipants(30)
+                        .build()
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        lectureApplicationRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("동시에 40명이 수강신청을 시도하면 30명만 성공해야 한다")
+    void concurrentApplicationTest() throws InterruptedException {
+        int numberOfThreads = 40;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            final String applicantId = "student" + i;
+            executorService.submit(() -> {
+                try {
+                    lectureService.applyForLecture(
+                            new LectureApplicationDto(testLecture.getId(), applicantId)
+                    );
+                    successCount.incrementAndGet();
+                } catch (RestApiException e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(10, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        assertEquals(30, successCount.get(), "성공한 수강신청 수가 30이어야 합니다");
+        assertEquals(10, failCount.get(), "실패한 수강신청 수가 10이어야 합니다");
+        assertEquals(30, lectureApplicationRepository.countByLectureId(testLecture.getId()));
+    }
+
+    @Test
+    @DisplayName("이미 수강신청한 학생이 다시 신청하면 예외가 발생해야 한다")
+    void duplicateApplicationTest() {
+        String applicantId = "student1";
+        LectureApplicationDto dto = new LectureApplicationDto(testLecture.getId(), applicantId);
+
+        // 첫 번째 신청
+        lectureService.applyForLecture(dto);
+
+        // 두 번째 신청
+        assertThrows(RestApiException.class, () -> {
+            lectureService.applyForLecture(dto);
+        });
+    }
+
+}

--- a/src/test/java/hhplus/cleanarchitecture/lecture/LectureApplicationIntegrationTest.java
+++ b/src/test/java/hhplus/cleanarchitecture/lecture/LectureApplicationIntegrationTest.java
@@ -54,8 +54,7 @@ class LectureApplicationIntegrationTest {
     }
 
     @Test
-    @DisplayName("동시에 40명이 수강신청을 시도하면 30명만 성공해야 한다")
-    void concurrentApplicationTest() throws InterruptedException {
+    void 동시다발적으로특강에신청이들어오면_정원만큼만성공하고나머진실패() throws InterruptedException {
         int numberOfThreads = 40;
         ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
         CountDownLatch latch = new CountDownLatch(numberOfThreads);
@@ -87,18 +86,19 @@ class LectureApplicationIntegrationTest {
     }
 
     @Test
-    @DisplayName("이미 수강신청한 학생이 다시 신청하면 예외가 발생해야 한다")
-    void duplicateApplicationTest() {
+    void 특강에중복신청을한다면_에러발생() {
         String applicantId = "student1";
         LectureApplicationDto dto = new LectureApplicationDto(testLecture.getId(), applicantId);
 
         // 첫 번째 신청
         lectureService.applyForLecture(dto);
 
-        // 두 번째 신청
-        assertThrows(RestApiException.class, () -> {
-            lectureService.applyForLecture(dto);
-        });
+        // 2번째 ~ 5번째 신청 - 모두 실패해야 함
+        for (int i = 2; i <= 5; i++) {
+            assertThrows(RestApiException.class, () -> {
+                lectureService.applyForLecture(dto);
+            });
+        }
     }
 
 }

--- a/src/test/java/hhplus/cleanarchitecture/lecture/LectureServiceTest.java
+++ b/src/test/java/hhplus/cleanarchitecture/lecture/LectureServiceTest.java
@@ -70,10 +70,9 @@ class LectureServiceTest {
         }
 
         @Test
-        @DisplayName("정상적으로 특강을 신청할 수 있다")
         void 특강신청_성공() {
             // given
-            given(lectureRepository.findById(1L)).willReturn(Optional.of(lecture));
+            given(lectureRepository.findByIdWithPessimisticLock(1L)).willReturn(Optional.of(lecture));
             given(lectureApplicationRepository.countByLectureId(1L)).willReturn(0);
 
             // when
@@ -86,7 +85,7 @@ class LectureServiceTest {
         @Test
         void 존재하지않는특강에신청_에러발생() {
             // given
-            given(lectureRepository.findById(1L)).willReturn(Optional.empty());
+            given(lectureRepository.findByIdWithPessimisticLock(1L)).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> sut.applyForLecture(lectureApplicationDto))
@@ -98,7 +97,7 @@ class LectureServiceTest {
         void 이미종료된특강에신청_에러발생() {
             // given
             Lecture expiredLecture = createLecture(1L, "종료된 강의", LocalDateTime.now().minusDays(1));
-            given(lectureRepository.findById(1L)).willReturn(Optional.of(expiredLecture));
+            given(lectureRepository.findByIdWithPessimisticLock(1L)).willReturn(Optional.of(expiredLecture));
 
             // when & then
             assertThatThrownBy(() -> sut.applyForLecture(lectureApplicationDto))
@@ -109,7 +108,7 @@ class LectureServiceTest {
         @Test
         void 정원초과된특강에신청_에러발생() {
             // given
-            given(lectureRepository.findById(1L)).willReturn(Optional.of(lecture));
+            given(lectureRepository.findByIdWithPessimisticLock(1L)).willReturn(Optional.of(lecture));
             given(lectureApplicationRepository.countByLectureId(1L)).willReturn(lecture.getLectureMaxParticipants());
 
             // when & then
@@ -121,7 +120,7 @@ class LectureServiceTest {
         @Test
         void 동일특강에중복신청_에러발생() {
             // given
-            given(lectureRepository.findById(1L)).willReturn(Optional.of(lecture));
+            given(lectureRepository.findByIdWithPessimisticLock(1L)).willReturn(Optional.of(lecture));
             given(lectureApplicationRepository.countByLectureId(1L)).willReturn(0);
             given(lectureApplicationRepository.save(any())).willThrow(new RuntimeException());
 
@@ -142,4 +141,3 @@ class LectureServiceTest {
                 .build();
     }
 }
-


### PR DESCRIPTION
작업 내역
1. DB ERD 설계 및 설명에 대한 readme 작성
- erd 와 ddl에 대한 이미지 첨부
2. 비관적 락을 통한 동시성 제어
- 동시다발적으로 '특강 신청'이 발생하는 경우를 생각했고 하나의 트랜잭션이 끝날 때까지 락을 점유하도록 만들었습니다.
3. 통합 테스트 작성
- 동시에 동일한 특강에 대해 40명이 신청했을 때, 30명만 성공하는 것을 검증
- 동일한 유저 정보로 같은 특강을 5번 신청했을 때, 1번만 성공하는 것을 검증

리뷰 포인트
- @Lock(LockModeType.PESSIMISTIC_WRITE) 어노테이션의 역할이 트랜잭션 동안 락을 점유하는 것으로 알고 썼는데 맞는 방향인지
- '특강 신청' 테이블에 중복 레코드를 방지하기 위해 unique key 전략을 썼는데 괜찮은 방향인지

TO-DO
- 분산 트랜잭션 환경에서의 동시성 제어는 어떻게 할 것인지 고민해보기